### PR TITLE
Fix email job logging with latest versions of Guzzle

### DIFF
--- a/public/old/includes/functions.mail.php
+++ b/public/old/includes/functions.mail.php
@@ -53,8 +53,8 @@ function sendMail($to, $subject, $message, $from, $bcc = '')
             break;
 
         default:
-            var_dump($dbMailId);
-            exit;
+            logFailedMailWithId($dbMailId, 'Mail provider not setup in config');
+            $mailSentOk = true;
             break;
     }
 

--- a/src/classes/Controller/JobController.php
+++ b/src/classes/Controller/JobController.php
@@ -20,12 +20,15 @@ class JobController extends BaseController
 
         $client = new Client();
         $url = $site->getUrl()['base'].$this->router->pathFor('home').'old/cr_daily.php';
-        $response = $client->get($url, [
+        $guzzleResponse = $client->get($url, [
             'query' => [
                 'token' => $args['token'],
             ],
         ]);
 
-        return $response;
+        $body = $response->getBody();
+        $body->write($guzzleResponse->getBody()->getContents());
+
+        return $response->withBody($body);
     }
 }


### PR DESCRIPTION
Guzzle 6.3.0 response body wasn't returning the stream in a way which could be passed directly out as slim's response (content was blank), though it worked on earlier versions of Guzzle.
Fixed by fetching content and creating a new response body stream.

Also fixed mock email sending for testing.